### PR TITLE
fix reporting add on

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -27,6 +27,10 @@ directory '/etc/opscode-analytics' do
   recursive true
 end
 
+directory '/etc/opscode-reporting' do
+  recursive true
+end
+
 chef_server_ingredient 'chef-server-core' do
   notifies :reconfigure, 'chef_server_ingredient[chef-server-core]'
 end

--- a/recipes/frontend.rb
+++ b/recipes/frontend.rb
@@ -24,7 +24,8 @@ node.default['chef-server-cluster']['role'] = 'frontend'
 
 # TODO: (jtimberman) chef_vault_item. We sort this so we don't
 # get regenerated content in the private-chef-secrets.json later.
-chef_secrets = Hash[data_bag_item('secrets', "private-chef-secrets-#{node.chef_environment}")['data'].sort]
+chef_secrets      = Hash[data_bag_item('secrets', "private-chef-secrets-#{node.chef_environment}")['data'].sort]
+reporting_secrets = Hash[data_bag_item('secrets', "opscode-reporting-secrets-#{node.chef_environment}")['data'].sort]
 
 # It's easier to deal with a hash rather than a data bag item, since
 # we're not going to need any of the methods, we just need raw data.
@@ -53,6 +54,12 @@ node.default['chef-server-cluster'].merge!(chef_server_config)
 file '/etc/opscode/private-chef-secrets.json' do
   content JSON.pretty_generate(chef_secrets)
   notifies :reconfigure, 'chef_server_ingredient[chef-server-core]'
+  sensitive true
+end
+
+file '/etc/opscode-reporting/opscode-reporting-secrets.json' do
+  content JSON.pretty_generate(reporting_secrets)
+  notifies :reconfigure, 'chef_server_ingredient[opscode-reporting]'
   sensitive true
 end
 


### PR DESCRIPTION
The Reporting add on needs to be installed on the backend node(s) too.

- Use a data bag for the secrets a la private-chef-secrets
- Always create the /etc/opscode-reporting directory
- Include the reporting ingredient on the bootstrap backend