### PR TITLE
Fixes #28, become driver agnostic

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,15 +22,27 @@ default['chef-server-cluster']['role'] = 'frontend'
 default['chef-server-cluster']['bootstrap']['enable'] = false
 default['chef-server-cluster']['chef-provisioner-key-name'] = 'hc-metal-provisioner-chef-aws-us-west-2'
 
+# We default to the aws driver, but by overriding this attribute
+# elsewhere (like a role, or a wrapper cookbook), other drivers should
+# be usable.
+default['chef-server-cluster']['driver'] = {
+                                            'gems' => [
+                                                      {
+                                                        'name' => 'chef-provisioning-aws',
+                                                        'require' => 'chef/provisioning/aws_driver'
+                                                      }
+                                                     ],
+                                            'with-parameter' => 'aws::us-west-2'
+                                           }
+
 # these use _ instead of - because it maps to the machine_options in
-# chef-provisioning-fog.
-default['chef-server-cluster']['aws']['region'] = 'us-west-2'
-default['chef-server-cluster']['aws']['machine_options'] = {
-                      :ssh_username => 'ubuntu',
-                      :use_private_ip_for_ssh => false,
-                      :bootstrap_options => {
-                                             :key_name => 'hc-metal-provisioner',
-                                             :image_id => 'ami-b99ed989',
-                                             :flavor_id => 'm3.medium'
+# chef-provisioning-aws, our default provisioning driver.
+default['chef-server-cluster']['driver']['machine_options'] = {
+                      'ssh_username' => 'ubuntu',
+                      'use_private_ip_for_ssh' => false,
+                      'bootstrap_options' => {
+                                             'key_name' => 'hc-metal-provisioner',
+                                             'image_id' => 'ami-b99ed989',
+                                             'instance_type' => 'm3.medium'
                                             }
                     }

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -23,4 +23,13 @@ module ChefHelpers
   def self.secret_files
     %w{pivotal.cert  pivotal.pem  webui_priv.pem  webui_pub.pem  worker-private.pem  worker-public.pem}
   end
+
+  def self.symbolize_keys_deep!(h)
+    Chef::Log.debug("#{h.inspect} is a hash with string keys, make them symbols")
+    h.keys.each do |k|
+      ks    = k.to_sym
+      h[ks] = h.delete k
+      symbolize_keys_deep! h[ks] if h[ks].kind_of? Hash
+    end
+  end
 end

--- a/recipes/cluster-provision.rb
+++ b/recipes/cluster-provision.rb
@@ -22,6 +22,11 @@
 include_recipe 'chef-server-cluster::setup-provisioner'
 include_recipe 'chef-server-cluster::setup-ssh-keys'
 
+# we're going to stash files locally with machine_file, keep them in a tempdir
+directory '/tmp/stash' do
+  recursive true
+end
+
 machine 'bootstrap-backend' do
   recipe 'chef-server-cluster::bootstrap'
   ohai_hints 'ec2' => '{}'

--- a/recipes/setup-ssh-keys.rb
+++ b/recipes/setup-ssh-keys.rb
@@ -16,36 +16,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-require 'chef/provisioning/fog_driver/driver'
-
 # This needs to move to a chef_vault_item, and use our internal `data`
 # convention for the sub-key of where the secrets are. It should also
 # use an attribute for the name, so basically uncomment this line when
 # we're ready for that.
 #ssh_keys = chef_vault_item('vault', node['chef-server-cluster']['chef-provisioner-key-name'])['data']
-
 ssh_keys = data_bag_item('secrets', node['chef-server-cluster']['chef-provisioner-key-name'])
+key_dir  = File.join(Dir.home, '.ssh')
+key_name = node['chef-server-cluster']['driver']['machine_options']['bootstrap_options']['key_name']
 
-directory '/tmp/ssh' do
+directory key_dir do
   recursive true
 end
 
-directory '/tmp/stash' do
-  recursive true
-end
-
-file '/tmp/ssh/id_rsa' do
+file File.join(key_dir, key_name) do
   content ssh_keys['private_ssh_key']
   sensitive true
 end
 
-file '/tmp/ssh/id_rsa.pub' do
+file File.join(key_dir, "#{key_name}.pub") do
   content ssh_keys['public_ssh_key']
   sensitive true
-end
-
-fog_key_pair node['chef-server-cluster']['aws']['machine_options']['bootstrap_options']['key_name'] do
-  private_key_path '/tmp/ssh/id_rsa'
-  public_key_path '/tmp/ssh/id_rsa.pub'
 end


### PR DESCRIPTION
This is a breaking change, attributes are removed.

This commit fixes #28 and #19. It generalizes the attributes so that
other drivers can be used. It also removes the use of fog_key_pair and
relies on the implicit management of SSH keys built into
chef-provisioning or chef-provisioning-{fog,aws}.

Specific changes follow:

* Rename the 'aws' attribute to 'driver' and make it more general
* Add with-parameter attribute to feed into the 'with_driver' method,
allowing more general connection URIs for drivers
* Add capability for installing and requiring chef provisioning driver
gems
* Update to use chef-provisioning-aws by default, changing the
flavor_id attribute to instance_type, as that is handed off to aws-sdk
* Add a new helper method #symbolize_keys_deep! that will convert the
machine_options keys to symbols to work around an issue in
chef-provisioning
* Update README
* Move 'stash' directory to cluster-provision recipe
* Adjust cluster-provision recipe to consume the new attributes changes
* Adjust the setup-ssh-keys recipe to use chef-provisioning's implicit
key configuration

It's important to note that we must use the ~/.ssh/KEY location to get
chef-provisioning's automatic handling of the key, because when running
in chef-client, it chdirs to /, making ./.chef/keys unusable. If a key
were created, it would get put into ~/.chef/keys, but we really want to
have the keys created beforehand at this point in time.

Issue in chef-provisioning regarding symbols vs strings:
https://github.com/chef/chef-provisioning/issues/304